### PR TITLE
修改docker镜像配置

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.idea
+runtime
+.git
+
+**/.next/**
+**/node_modules/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /app
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories
 RUN npm config set registry https://registry.npmmirror.com
 RUN npm i -g pm2 @nestjs/cli pnpm
-RUN apk --no-cache add bash
+RUN apk --no-cache add bash dos2unix \
+    && find . -name "*.sh" -exec dos2unix {} \; \
+    && apk del dos2unix
 RUN bash build-output.sh
 
 FROM node:18-alpine as prod

--- a/packages/client/src/components/admin/system-config/mail/index.tsx
+++ b/packages/client/src/components/admin/system-config/mail/index.tsx
@@ -51,16 +51,16 @@ export const Mail = () => {
             />
 
             <Form.Input
-              field="emailServicePassword"
-              label="邮件服务密码"
+              field="emailServiceUser"
+              label="邮件服务用户"
               style={{ width: '100%' }}
-              placeholder="输入邮件服务密码"
-              rules={[{ required: true, message: '请输入邮件服务密码' }]}
+              placeholder="输入邮件服务用户名"
+              rules={[{ required: true, message: '请输入邮件服务用户名' }]}
             />
 
             <Form.Input
-              field="emailServiceUser"
-              label="邮件服务用户"
+              field="emailServicePassword"
+              label="邮件服务密码"
               style={{ width: '100%' }}
               placeholder="输入邮件服务密码"
               rules={[{ required: true, message: '请输入邮件服务密码' }]}


### PR DESCRIPTION
1. 减小docker镜像体积
本地开发之后再构建docker镜像，发现镜像体积达到将近4G
2. windows下git签出文件默认为crlf格式，在linux脚本无法正常运行
