### PR TITLE
fix: 修复cos获取的是临时链接导致的图片加载403问题

### DIFF
--- a/packages/server/src/helpers/file.helper/tencent.client.ts
+++ b/packages/server/src/helpers/file.helper/tencent.client.ts
@@ -78,7 +78,7 @@ export class TencentOssClient extends BaseOssClient {
         if (err) {
           resolve(false);
         } else {
-          this.client.getObjectUrl(params, (err, data) => {
+          this.client.getObjectUrl({ ...params, Sign: false }, (err, data) => {
             if (err) {
               reject(err);
             } else {
@@ -114,7 +114,7 @@ export class TencentOssClient extends BaseOssClient {
           if (err) {
             reject(err);
           }
-          this.client.getObjectUrl(params, (err, data) => {
+          this.client.getObjectUrl({ ...params, Sign: false }, (err, data) => {
             if (err) {
               reject(err);
             } else {
@@ -193,7 +193,7 @@ export class TencentOssClient extends BaseOssClient {
                 if (err) {
                   reject(err);
                 } else {
-                  this.client.getObjectUrl(params, (err, data) => {
+                  this.client.getObjectUrl({ ...params, Sign: false }, (err, data) => {
                     if (err) {
                       reject(err);
                     } else {


### PR DESCRIPTION
这个问题是：我使用COS时，获取的资源链接是一个临时链接他是有时效的，当这个链接保存在数据库中会在后面的加载过程中失效，具体表现为资源403。
当前的改动是：获取原生链接不会存在失效403问题