### PR TITLE
feature: 增加版本比对

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -63,6 +63,7 @@
     "dompurify": "^2.3.5",
     "downloadjs": "^1.4.7",
     "html-to-docx": "^1.4.0",
+    "htmldiff-js": "^1.0.5",
     "interactjs": "^1.10.11",
     "katex": "^0.15.2",
     "kity": "^2.0.4",

--- a/packages/client/src/components/document/version/index.module.scss
+++ b/packages/client/src/components/document/version/index.module.scss
@@ -39,6 +39,44 @@
         overflow: auto;
       }
     }
+
+    :global {
+      #diff-visual {
+        del {
+          color: #cb4000;
+          text-decoration: none;
+          list-style: none;
+          background-color: #ffeaea;
+        }
+
+        del::before {
+          position: relative;
+          top: -2px;
+          padding: 0 4px;
+          font-weight: 400;
+          color: #8a8f8d;
+          text-decoration: none;
+          content: '-';
+        }
+
+        ins {
+          color: green;
+          text-decoration: none;
+          list-style: none;
+          background-color: #e9ffe9;
+        }
+
+        ins::before {
+          position: relative;
+          top: -2px;
+          padding: 0 4px;
+          font-weight: 400;
+          color: #8a8f8d;
+          text-decoration: none;
+          content: '+';
+        }
+      }
+    }
   }
 
   aside {

--- a/packages/client/src/helpers/generate-html.ts
+++ b/packages/client/src/helpers/generate-html.ts
@@ -1,0 +1,12 @@
+import { generateHTML } from '@tiptap/core';
+import HtmlDiff from 'htmldiff-js';
+import { CollaborationKit } from 'tiptap/editor';
+
+const json2html = (json) => generateHTML(json, CollaborationKit);
+export const generateDiffHtml = (selected, other) => {
+  const selectedHtml = json2html(selected);
+  const otherHtml = json2html(other);
+  let diffHtml = HtmlDiff.execute(selectedHtml, otherHtml);
+  diffHtml = diffHtml.replace(/<iframe\s*[^>]*>(.*?)<\/iframe>/gi, '');
+  return diffHtml;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,7 @@ importers:
       eslint-plugin-simple-import-sort: ^7.0.0
       fs-extra: ^10.0.0
       html-to-docx: ^1.4.0
+      htmldiff-js: ^1.0.5
       interactjs: ^1.10.11
       katex: ^0.15.2
       kity: ^2.0.4
@@ -207,6 +208,7 @@ importers:
       dompurify: 2.3.5
       downloadjs: 1.4.7
       html-to-docx: 1.4.0
+      htmldiff-js: 1.0.5
       interactjs: 1.10.11
       katex: 0.15.2
       kity: 2.0.4
@@ -6706,6 +6708,10 @@ packages:
     dependencies:
       ent: 2.2.0
       htmlparser2: 3.10.1
+    dev: false
+
+  /htmldiff-js/1.0.5:
+    resolution: {integrity: sha512-rmow9353OK0elkub15Sbze8Nj7BYfduqoJJw4yEvHHjOcHeCazNPk0PoUbjE8SvxKgjymeRIFU/OnS8jtitRtA==}
     dev: false
 
   /htmlparser2/3.10.1:


### PR DESCRIPTION
1. 新功能：历史版本比对 （仅在PC端展示，手机端不太好做复杂的比对展示与操作，所以功能隐藏不开放）
2. 依赖：使用html-diff.js作为diff html的核心库
3. 局限性：
     - 当前仅为第一个版本，部分样式参考语雀
     - 在内部diff算法上面，tiptap的generateHTML 还不兼容自定义的部分插件比如流程图、脑图，那么现在是把iframe的标签过滤掉了，后面可以再优化
     - 当前比对的质量取决于JSON转化成HTMl的质量